### PR TITLE
Implemented functions to interpret color escapes

### DIFF
--- a/interpret.go
+++ b/interpret.go
@@ -1,0 +1,196 @@
+package rgbterm
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MaxEscapeCodeLen is the maximum number of bytes that the contents of an escape
+// code may be. If the escape code is longer than this, it is output verbatim
+// without being replaced. If MaxEscapeCodeLen is set to 0 escape codes may be
+// any length (checking is not performed)
+//
+// This is used to avoid a possible denial of service.
+var MaxEscapeCodeLen uint = 15
+
+// interpret reads from r and writes to w. While reading any color escape codes detected
+// are replaced by the result of calling subst with the escape code.
+func interpret(r io.ByteReader, w io.Writer, subst func(s string) []byte) error {
+	inEscape := false
+	escape := &bytes.Buffer{}
+
+	for {
+		c, err := r.ReadByte()
+		if err != nil {
+			// EOF
+			break
+		}
+
+		if inEscape {
+			if rune(c) == '{' && escape.Len() == 0 {
+				// False alarm: this was the sequence {{ which means the user wanted to
+				// output {.
+				_, err = w.Write([]byte("{"))
+				escape.Reset()
+				inEscape = false
+			} else if rune(c) == '}' {
+				_, err = w.Write(subst(escape.String()))
+				escape.Reset()
+				inEscape = false
+			} else {
+				escape.WriteByte(c)
+				if MaxEscapeCodeLen > 0 && uint(escape.Len()) > MaxEscapeCodeLen {
+					// Escape code too long
+					w.Write([]byte("{"))
+					_, err = w.Write(escape.Bytes())
+					inEscape = false
+				}
+			}
+		} else {
+			if rune(c) == '{' {
+				inEscape = true
+			} else {
+				_, err = w.Write([]byte{c})
+			}
+		}
+
+		if err != nil {
+			// Write error occurred
+			return err
+		}
+	}
+
+	return nil
+}
+
+// colorRegex matches color escape codes
+var colorRegex *regexp.Regexp = regexp.MustCompile(`#([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2})`)
+
+func parseEscape(s string) ([]uint8, []uint8) {
+	parts := strings.Split(s, ",")
+
+	atoi := func(s []string) (r []uint8) {
+		r = make([]uint8, len(s))
+		for i, v := range s {
+			i64, _ := strconv.ParseInt(v, 16, 0)
+			r[i] = uint8(i64)
+		}
+		return
+	}
+
+	escapes := make([][]uint8, 2)
+	for i, p := range parts {
+		match := colorRegex.FindStringSubmatch(p)
+		if match != nil {
+			escapes[i] = atoi(match[1:])
+		}
+	}
+
+	return escapes[0], escapes[1]
+}
+
+func substColor(s string) (c []byte) {
+	fg, bg := parseEscape(s)
+
+	if fg == nil && bg == nil {
+		// Reset colors to default
+		return reset
+	}
+
+	if fg != nil {
+		c = append(c, color(fg[0], fg[1], fg[2], true)...)
+	}
+	if bg != nil {
+		if len(c) > 0 {
+			c = append(c, byte(';'))
+		}
+
+		c = append(c, color(bg[0], bg[1], bg[2], false)...)
+	}
+
+	c = append(before, c...)
+	c = append(c, after...)
+
+	return
+}
+
+// Interpret reads data from r and writes it to w,
+// while substituting the color escapes in the input.
+//
+// Color escapes are directives having one of forms
+// on the following lines:
+//
+//   {#RRGGBB}
+//   {#RRGGBB,#RRGGBB}
+//   {,#RRGGBB}
+//   {}
+//
+// The first form sets the terminal foreground color to
+// the color RR,GG,BB where RR is the red component,
+// GG green and BB blue. Each component is in hex.
+//
+// The second form sets the foreground and background
+// colors, while the third sets only the background.
+//
+// The fourth form resets the terminal colors to defaults.
+//
+// To output a literal { character, use two braces: {{.
+func Interpret(r io.ByteReader, w io.Writer) error {
+	return interpret(r, w, substColor)
+}
+
+// ColorizeTemplate substitutes the color escapes in the
+// string s and returns the resulting string.
+//
+// See Interpret for a description of color escapes.
+func InterpretStr(s string) string {
+	var out bytes.Buffer
+	Interpret(bytes.NewBuffer([]byte(s)), &out)
+	return out.String()
+}
+
+// ColorTemplateWriter writes to an underlying io.Writer
+// while substituting the color escapes in the input.
+//
+// See Interpret for a description of color escapes.
+type InterpretingWriter struct {
+	p *io.PipeWriter
+}
+
+// NewColorTemplateWriter creates a ColorTemplateWriter that writes to
+// w while substituting the color escapes in the input.
+//
+// See Interpret for a description of color escapes.
+func NewInterpretingWriter(w io.Writer) InterpretingWriter {
+	pr, pw := io.Pipe()
+
+	go Interpret(bufio.NewReader(pr), w)
+
+	return InterpretingWriter{p: pw}
+}
+
+// Write writes to the underlying io.Writer while substituting the
+// color escapes in the input.
+//
+// See Interpret for a description of color escapes.
+func (tw InterpretingWriter) Write(p []byte) (n int, err error) {
+	return tw.p.Write(p)
+}
+
+var (
+	// ColorOut is a io.Writer that writes to os.Stdout
+	// while substituting the the color escapes in it's input.
+	//
+	// See Interpret for a description of color escapes.
+	ColorOut io.Writer = NewInterpretingWriter(os.Stdout)
+	// ColorErr is a io.Writer that writes to os.Stderr
+	// while substituting the the color escapes in it's input.
+	//
+	// See Interpret for a description of color escapes.
+	ColorErr io.Writer = NewInterpretingWriter(os.Stderr)
+)

--- a/interpret_test.go
+++ b/interpret_test.go
@@ -1,0 +1,202 @@
+package rgbterm
+
+import (
+	"bytes"
+	"testing"
+)
+
+func bufsForTest(s string) (inputBuf *bytes.Buffer, outputBuf *bytes.Buffer) {
+	inputBuf = bytes.NewBufferString(s)
+	outputBuf = &bytes.Buffer{}
+	return
+}
+
+func TestInterpretNoEscapes(t *testing.T) {
+	s := "No escapes here."
+	input, output := bufsForTest("No escapes here.")
+
+	cnt := 0
+
+	subst := func(s string) []byte {
+		cnt++
+		return nil
+	}
+
+	interpret(input, output, subst)
+	if cnt != 0 {
+		t.FailNow()
+	}
+
+	if output.String() != s {
+		t.FailNow()
+	}
+}
+
+func TestInterpretOutputBrace(t *testing.T) {
+	sin := "We have {{no} escapes here."
+	sout := "We have {no} escapes here."
+	input, output := bufsForTest(sin)
+
+	cnt := 0
+
+	subst := func(s string) []byte {
+		cnt++
+		return []byte{}
+	}
+
+	interpret(input, output, subst)
+	if cnt != 0 {
+		t.FailNow()
+	}
+
+	if output.String() != sout {
+		t.FailNow()
+	}
+}
+
+func TestInterpretEmptyReplace(t *testing.T) {
+	sin := "We have {some} escapes here."
+	sout := "We have  escapes here."
+	input, output := bufsForTest(sin)
+
+	cnt := 0
+
+	subst := func(s string) []byte {
+		cnt++
+		return []byte{}
+	}
+
+	interpret(input, output, subst)
+	if cnt != 1 {
+		t.FailNow()
+	}
+
+	if output.String() != sout {
+		t.FailNow()
+	}
+}
+
+func TestInterpretNilReplace(t *testing.T) {
+	sin := "We have {some} escapes here."
+	sout := "We have  escapes here."
+	input, output := bufsForTest(sin)
+
+	cnt := 0
+
+	subst := func(s string) []byte {
+		if s != "some" {
+			t.FailNow()
+		}
+		cnt++
+		return nil
+	}
+
+	interpret(input, output, subst)
+	if cnt != 1 {
+		t.FailNow()
+	}
+
+	if output.String() != sout {
+		t.FailNow()
+	}
+}
+
+func TestInterpretSomeReplaces(t *testing.T) {
+	sin := "We have {some} escapes {more} here."
+	sout := "We have more escapes more here."
+	input, output := bufsForTest(sin)
+
+	cnt := 0
+
+	subst := func(s string) []byte {
+		if s != "some" && s != "more" {
+			t.FailNow()
+		}
+		cnt++
+		return []byte("more")
+	}
+
+	interpret(input, output, subst)
+	if cnt != 2 {
+		t.FailNow()
+	}
+
+	if output.String() != sout {
+		t.FailNow()
+	}
+}
+
+func TestInterpretReplaceTooLong(t *testing.T) {
+	sin := "We have {#0a0a0a,#0a0a0a,}"
+	input, output := bufsForTest(sin)
+
+	cnt := 0
+
+	subst := func(s string) []byte {
+		cnt++
+		return []byte{}
+	}
+
+	interpret(input, output, subst)
+	if cnt != 0 {
+		t.Log("Count is", cnt)
+		t.FailNow()
+	}
+
+	if output.String() != sin {
+		t.Log("Str is", output.String())
+		t.FailNow()
+	}
+}
+
+func TestParseEmptyEscape(t *testing.T) {
+	fg, bg := parseEscape("")
+
+	if fg != nil || bg != nil {
+		t.FailNow()
+	}
+}
+
+func TestParseInvalidEscape(t *testing.T) {
+	fg, bg := parseEscape("invl")
+
+	if fg != nil || bg != nil {
+		t.FailNow()
+	}
+}
+
+func TestParseFgEscape(t *testing.T) {
+	fg, bg := parseEscape("#0a0501")
+
+	if fg[0] != 0xa || fg[1] != 0x5 || fg[2] != 0x1 {
+		t.FailNow()
+	}
+
+	if bg != nil {
+		t.FailNow()
+	}
+}
+
+func TestParseFgBgEscape(t *testing.T) {
+	fg, bg := parseEscape("#0a0501,#fffefd")
+
+	if fg[0] != 0xa || fg[1] != 0x5 || fg[2] != 0x1 {
+		t.FailNow()
+	}
+
+	if bg[0] != 0xff || bg[1] != 0xfe || bg[2] != 0xfd {
+		t.FailNow()
+	}
+}
+
+func TestParseBgEscape(t *testing.T) {
+	fg, bg := parseEscape(",#fffefd")
+
+	if fg != nil {
+		t.FailNow()
+	}
+
+	if bg[0] != 0xff || bg[1] != 0xfe || bg[2] != 0xfd {
+		t.FailNow()
+	}
+}

--- a/rgbterm.go
+++ b/rgbterm.go
@@ -18,6 +18,13 @@
 //
 //	fmt.Println("Oh!", coloredWord, "hello!")
 //
+// Alternately, use ColorOut or one of the Interpret functions to output
+// a string with color escape codes:
+//
+//  fmt.Fprintln(rgbterm.ColorOut, "Let's print some {#ff0000}red{} and {#00ff00}green{} text")
+//  fmt.Fprintln(rgbterm.ColorOut, "Let's print some {#8080ff}blue,")
+//  fmt.Fprintln(rgbterm.ColorOut, "blue, blue{} text.")
+//
 // The RGB <-> HSL helpers were shamelessly taken from gorilla color, BSD 2 clauses
 // licensed:
 //    https://code.google.com/p/gorilla/source/browse/?r=ef489f63418265a7249b1d53bdc358b09a4a2ea0#hg%2Fcolor


### PR DESCRIPTION
Hey!

I added functions so that callers can embed special escapes into text strings such as {#ff0000} to
change the current fg or bg colors. Also I defined versions of Stdout and Stderr that interpret these escapes. For example:

    fmt.Println(rgbterm.InterpretStr("Some {#ff0000}red{} text"))
    fmt.Println(rgbterm.InterpretStr("Some {,#ff0000}red background{} text"))
    fmt.Println(rgbterm.InterpretStr("Some {#0000ff,#ff0000}blue on red{} text"))

    fmt.Fprintln(rgbterm.ColorOut, "Let's print some {#ff0000}red{} and {#00ff00}green{} text")

    fmt.Fprintln(rgbterm.ColorOut, "Let's print some {#8080ff} blue,")
    fmt.Fprintln(rgbterm.ColorOut, "blue, blue{} text.")

    fmt.Fprintf(rgbterm.ColorOut, "Uh oh! a {#80ff")
    fmt.Fprintln(rgbterm.ColorOut, "80}partial{} escape!")
